### PR TITLE
Expose the expires property in TypeScript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,7 @@ declare namespace ClientOAuth2 {
     tokenType: string;
     accessToken: string;
     refreshToken: string;
+    expires: Date;
 
     constructor(client: ClientOAuth2, data: Data);
     expiresIn(duration: number | Date): Date;


### PR DESCRIPTION
Currently, Using TypeScript there is no way to get the time in which the token expires (As far as I know) due to the `expires` property being hidden.